### PR TITLE
feat: add notice dialog

### DIFF
--- a/src/partials/download-dialog.hbs
+++ b/src/partials/download-dialog.hbs
@@ -3,10 +3,10 @@
         <div class="mdc-dialog__surface"
              role="alertdialog"
              aria-modal="true"
-             aria-labelledby="Download"
-             aria-describedby="Select the download file format">
-            <h2 class="mdc-dialog__title">Choose a format</h2>
-            <div class="mdc-dialog__content">
+             aria-labelledby="download-dialog-title"
+             aria-describedby="download-dialog-content">
+            <h2 id="download-dialog-title" class="mdc-dialog__title">Choose a format</h2>
+            <div class="mdc-dialog__content" id="download-dialog-content">
                 <ul class="mdc-list">
                     <li class="mdc-list-item" tabindex="0">
                         <span class="mdc-list-item__graphic">

--- a/src/partials/download-dialog.hbs
+++ b/src/partials/download-dialog.hbs
@@ -1,12 +1,13 @@
-<div id="download-dialog" class="mdc-dialog js-only">
+<div id="download-dialog" class="mdc-dialog js-only"
+     role="alertdialog"
+     aria-modal="true"
+     aria-labelledby="download-dialog-title"
+     aria-describedby="download-dialog-content">
+    >
     <div class="mdc-dialog__container">
-        <div class="mdc-dialog__surface"
-             role="alertdialog"
-             aria-modal="true"
-             aria-labelledby="download-dialog-title"
-             aria-describedby="download-dialog-content">
+        <div class="mdc-dialog__surface">
             <h2 id="download-dialog-title" class="mdc-dialog__title">Choose a format</h2>
-            <div class="mdc-dialog__content" id="download-dialog-content">
+            <div id="download-dialog-content" class="mdc-dialog__content">
                 <ul class="mdc-list">
                     <li class="mdc-list-item" tabindex="0">
                         <span class="mdc-list-item__graphic">
@@ -23,7 +24,9 @@
                             {{fontawesome "fa" "FileCode"}}
                         </span>
                         <span class="mdc-list-item__text">
-                            <a href="#" onclick="this.href='data:text/html;charset=UTF-8,'+encodeURIComponent(document.documentElement.outerHTML)" target="_blank" download="resume.html" data-mdc-dialog-action="accept">
+                            <a href="#"
+                               onclick="this.href='data:text/html;charset=UTF-8,'+encodeURIComponent(document.documentElement.outerHTML)"
+                               target="_blank" download="resume.html" data-mdc-dialog-action="accept">
                                 HTML
                             </a>
                         </span>

--- a/src/partials/notice-dialog.hbs
+++ b/src/partials/notice-dialog.hbs
@@ -1,0 +1,23 @@
+{{#with resume.meta.notice }}
+    <div id="notice-dialog" class="mdc-dialog"
+         role="alertdialog"
+         aria-modal="true"
+         aria-labelledby="notice-dialog-title"
+         aria-describedby="notice-dialog-content">
+        <div class="mdc-dialog__container">
+            <div class="mdc-dialog__surface">
+                <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
+                <h2 class="mdc-dialog__title" id="notice-dialog-title">{{ title }}</h2>
+                <div class="mdc-dialog__content" id="notice-dialog-content">
+                    {{{ markdown content }}}
+                </div>
+                <footer class="mdc-dialog__actions">
+                    <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="close">
+                        <span class="mdc-button__label">OK</span>
+                    </button>
+                </footer>
+            </div>
+        </div>
+        <div class="mdc-dialog__scrim"></div>
+    </div>
+{{/with}}

--- a/src/partials/notice-dialog.hbs
+++ b/src/partials/notice-dialog.hbs
@@ -6,7 +6,6 @@
          aria-describedby="notice-dialog-content">
         <div class="mdc-dialog__container">
             <div class="mdc-dialog__surface">
-                <!-- Title cannot contain leading whitespace due to mdc-typography-baseline-top() -->
                 <h2 class="mdc-dialog__title" id="notice-dialog-title">{{ title }}</h2>
                 <div class="mdc-dialog__content" id="notice-dialog-content">
                     {{{ markdown content }}}

--- a/src/resume.hbs
+++ b/src/resume.hbs
@@ -37,6 +37,7 @@
     {{/if}}
 </head>
 <body class="{{#if options.printPreview.enabled}}{{#if options.printPreview.size}}{{options.printPreview.size}}{{else}}A4{{/if}}{{/if}}">
+{{> notice-dialog }}
 {{> page-header }}
 {{> top-app-bar }}
 {{> drawer }}

--- a/src/resume.js
+++ b/src/resume.js
@@ -135,12 +135,19 @@ document.addEventListener("DOMContentLoaded", function () {
     window.addEventListener('resize', resizeHandler);
 
     /** Material Dialog **/
-    const downloadDialogList = new MDCList(document.querySelector('.mdc-dialog .mdc-list'));
-    window.downloadDialog = new MDCDialog(document.querySelector('.mdc-dialog'));
-
-    window.downloadDialog.listen('MDCDialog:opened', () => {
-        downloadDialogList.layout();
+    const downloadDialogElement =document.querySelector('#download-dialog');
+    const downloadDialog = new MDCDialog(downloadDialogElement);
+    window.downloadDialog = downloadDialog
+    downloadDialog.listen('MDCDialog:opened', () => {
+        // 👇 not sure why this was needed TBH
+        new MDCList(downloadDialogElement.querySelector('.mdc-list')).layout();
     });
+
+    const noticeDialogElement =document.querySelector('#notice-dialog');
+    if(noticeDialogElement) {
+        const noticeDialog = new MDCDialog(noticeDialogElement);
+        noticeDialog.open()
+    }
 });
 
 


### PR DESCRIPTION
So that a dialog is displayed upon opening the page. This is because I have a new resume at https://davidlj95.com/resume/ but want to keep the one built with this theme at https://resume.davidlj95.com for showcasing purposes.

A `notice` property must be added in the `meta` section of JSON Resume to create this dialog. Example:

```json
{
  // ...
  "meta": {
    "notice": {
        "title": "Dialog title"
        "content": "Dialog content. Markdown accepted. Will be translated into HTML"
    }
  }
}
```
